### PR TITLE
Properly stop timer upon termination.

### DIFF
--- a/idapomidor.py
+++ b/idapomidor.py
@@ -327,7 +327,10 @@ class idapomidor_t(plugin_t):
         idapomidor_manager.show_pomidor()
 
     def term(self):
-        pass
+        global idapomidor_manager
+        if idapomidor_manager.timer.isActive():
+            idapomidor_manager.timer.stop()
+            del idapomidor_manager
         
 
 def PLUGIN_ENTRY():


### PR DESCRIPTION
Was causing a crash on OSX, this should prevent
the time from running upon plugin termination.
